### PR TITLE
host object may not contain hardware_info

### DIFF
--- a/discovery-infra/bm_inventory_api.py
+++ b/discovery-infra/bm_inventory_api.py
@@ -89,7 +89,7 @@ class InventoryClient(object):
         hosts = self.get_cluster_hosts(cluster_id)
         hosts_data = {}
         for host in hosts:
-            hw = json.loads(host["hardware_info"])
+            hw = json.loads(host.get("hardware_info", '{"nics":[]}')
             hosts_data[host["id"]] = [nic["mac"] for nic in hw["nics"]]
         return hosts_data
 
@@ -97,7 +97,7 @@ class InventoryClient(object):
         hosts = self.get_cluster_hosts(cluster_id)
 
         for host in hosts:
-            hw = json.loads(host["hardware_info"])
+            hw = json.loads(host.get("hardware_info", '{"nics":[]}')
             if mac.lower() in [nic["mac"].lower() for nic in hw["nics"]]:
                 return host
 


### PR DESCRIPTION
In case the host just registered and didn't send hardware_info the host object returened from bm-inventory will not contain hardware_info filed.
This cause randome failures in the CI e.g.: http://10.0.9.195:8080/job/test-infra/620/console